### PR TITLE
Hotfix/gpu docker

### DIFF
--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -19,9 +19,12 @@ services:
         reservations:
           devices:
           - capabilities: [gpu]
+            #runtime: nvidia
+            #command: nvidia-smi
     ports:
       - "5000:5000"
     environment:
+      - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES}
       - GC_ML_HOST=${GC_ML_HOST}
       - REDIS_HOST=${REDIS_HOST}
       - REDIS_PORT=${REDIS_PORT}

--- a/api/fastapi/mlapp.Dockerfile
+++ b/api/fastapi/mlapp.Dockerfile
@@ -1,4 +1,12 @@
-FROM nvidia/cuda:11.0-base
+FROM python:3.6.13-buster
+#FROM nvidia/cuda:11.0-base
+RUN curl -s -L https://nvidia.github.io/nvidia-container-runtime/gpgkey | \
+  apt-key add -
+# distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
+RUN curl -s -L https://nvidia.github.io/nvidia-container-runtime/ubuntu18.04/nvidia-container-runtime.list | \
+  tee /etc/apt/sources.list.d/nvidia-container-runtime.list
+RUN apt-get update
+RUN apt-get install -y nvidia-container-runtime
 CMD nvidia-smi
 #set up environment
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y curl


### PR DESCRIPTION
- ML API works on local now (with or without gpu) and using our own base image again. 