### PR TITLE
Task/uot 105092 add ml api dev container network to shared app network

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/gamechangerml/api/docker-compose.yml
+++ b/gamechangerml/api/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     command: --port 6380
     expose:
       - "6380"
+    networks:
+      - app-net
   gamechanger-ml-gpu:
     container_name: gc-ml-gpu
     image: gamechanger-ml-gpu
@@ -32,3 +34,9 @@ services:
       - ~/.aws/:/.aws
     depends_on:
       - gc-redis
+    networks:
+      - app-net
+
+networks:
+  app-net:
+    name: "${COMPOSE_PROJECT_NAME:-gc-dev}-network"


### PR DESCRIPTION
This PR adds the gamechanger ml containers spun up through docker compose to the same network used by other components of the GAMECHANGER environment. 

Also adds a .gitattributes file that ensures that shell scripts have lf line ends. This is useful so that Windows users don't need to run `dos2unix` or otherwise convert the shell script line endings before building the project containers.