### PR TITLE
Task/uot 109769 - adding QE to eval pipeline

### DIFF
--- a/gamechangerml/api/fastapi/model_loader.py
+++ b/gamechangerml/api/fastapi/model_loader.py
@@ -1,6 +1,6 @@
 import os
 from gamechangerml.src.search.QA.QAReader import DocumentReader as QAReader
-from gamechangerml.configs.config import QAConfig, EmbedderConfig, SimilarityConfig
+from gamechangerml.configs.config import QAConfig, EmbedderConfig, SimilarityConfig, QEConfig
 from gamechangerml.src.search.query_expansion import qe
 from gamechangerml.src.search.sent_transformer.model import SentenceSearcher
 from gamechangerml.src.search.embed_reader import sparse
@@ -72,7 +72,7 @@ class ModelLoader:
         logger.info(f"Loading Query Expansion Model from {qexp_model_path}")
         try:
             ModelLoader.__query_expander = qe.QE(
-                qexp_model_path, method="emb", vocab_file="word-freq-corpus-20201101.txt"
+                **QEConfig.MODEL_ARGS['init']
             )
             logger.info("** Loaded Query Expansion Model")
         except Exception as e:

--- a/gamechangerml/api/fastapi/routers/search.py
+++ b/gamechangerml/api/fastapi/routers/search.py
@@ -10,6 +10,8 @@ from gamechangerml.src.featurization.summary import GensimSumm
 from gamechangerml.api.fastapi.settings import *
 from gamechangerml.api.fastapi.model_loader import ModelLoader
 
+from gamechangerml.configs.config import QEConfig
+
 router = APIRouter()
 MODELS = ModelLoader()
 
@@ -147,7 +149,7 @@ async def post_expand_query_terms(termsList: dict, response: Response) -> dict:
     try:
         for term in termsList:
             term = unquoted(term)
-            expansion_list = MODELS.query_expander.expand(term)
+            expansion_list = MODELS.query_expander.expand(term, **QEConfig.MODEL_ARGS['expansion'])
             # turn word pairs into search phrases since otherwise it will just search for pages with both words on them
             # removing original word from the return terms unless it is combined with another word
             logger.info(f"original expanded terms: {expansion_list}")

--- a/gamechangerml/configs/config.py
+++ b/gamechangerml/configs/config.py
@@ -94,6 +94,7 @@ class QEConfig:
     MODEL_ARGS = {
         "init": { # args for creating QE object
             "qe_model_dir": "gamechangerml/models/qexp_20201217",
+            "qe_files_dir": "gamechangerml/src/search/query_expansion",
             "method": "emb", 
             "vocab_file": "word-freq-corpus-20201101.txt"
         },

--- a/gamechangerml/configs/config.py
+++ b/gamechangerml/configs/config.py
@@ -90,6 +90,20 @@ class SimilarityConfig:
         "model_name": "distilbart-mnli-12-3" # SOURCE
     }
 
+class QEConfig:
+    MODEL_ARGS = {
+        "init": { # args for creating QE object
+            "qe_model_dir": "gamechangerml/models/qexp_20201217",
+            "method": "emb", 
+            "vocab_file": "word-freq-corpus-20201101.txt"
+        },
+        "expansion": { # configs for getting expanded terms
+            "topn": 2, 
+            "threshold": 0.2, 
+            "min_tokens": 3
+        }
+    }
+
 class ValidationConfig:
     DATA_ARGS = {
         "validation_dir": "gamechangerml/data/validation", # need to have validation data in here

--- a/gamechangerml/configs/config.py
+++ b/gamechangerml/configs/config.py
@@ -128,5 +128,6 @@ class ValidationConfig:
         },
         "retriever_gc": {
             "gold_standard": "gold_standard.csv"
-        }
+        },
+        "qe_gc": "QE_domain.json"
     }

--- a/gamechangerml/data/validation/QE_domain.json
+++ b/gamechangerml/data/validation/QE_domain.json
@@ -1,0 +1,6 @@
+{
+    "queries": {
+        "network": ["connection", "communications"],
+        "weapons": ["enemy", "explosives"]
+    }
+}

--- a/gamechangerml/scripts/run_evaluation.py
+++ b/gamechangerml/scripts/run_evaluation.py
@@ -1,26 +1,33 @@
-from gamechangerml.src.model_testing.evaluation import SQuADQAEvaluator, IndomainQAEvaluator, IndomainRetrieverEvaluator, MSMarcoRetrieverEvaluator, SimilarityEvaluator
+#from gamechangerml.src.model_testing.evaluation import SQuADQAEvaluator, IndomainQAEvaluator, IndomainRetrieverEvaluator, MSMarcoRetrieverEvaluator, SimilarityEvaluator, QEEvaluator
+from gamechangerml.src.model_testing.evaluation import QEEvaluator
 from gamechangerml.api.utils.logger import logger
 
 if __name__ == '__main__':
 
-    logger.info("\nStarting QA Evaluation...")
-    logger.info("\nEvaluating QA with SQuAD Data...")
-    QAEval = SQuADQAEvaluator(model=None, sample_limit=20)
-    logger.info(QAEval.results)
-    logger.info("\nEvaluating QA with in-domain data...")
-    GCEval = IndomainQAEvaluator(model=None)
-    logger.info(GCEval.results)
+    #logger.info("\nStarting QA Evaluation...")
+    #logger.info("\nEvaluating QA with SQuAD Data...")
+    #QAEval = SQuADQAEvaluator(model=None, sample_limit=20)
+    #logger.info(QAEval.results)
+    #logger.info("\nEvaluating QA with in-domain data...")
+    #GCEval = IndomainQAEvaluator(model=None)
+    #logger.info(GCEval.results)
 
-    logger.info("\nStarting Retriever Evaluation...")
-    logger.info("\nEvaluating Retriever with MSMarco Data...")
-    MSMarcoEval = MSMarcoRetrieverEvaluator(encoder=None, retriever=None)
-    logger.info(MSMarcoEval.results)
-    logger.info("\nEvaluating Retriever with in-domain data...")
-    GoldStandardRetrieverEval = IndomainRetrieverEvaluator(encoder=None, retriever=None)
-    logger.info(GoldStandardRetrieverEval.results)
+    #logger.info("\nStarting Retriever Evaluation...")
+    #logger.info("\nEvaluating Retriever with MSMarco Data...")
+    #MSMarcoEval = MSMarcoRetrieverEvaluator(encoder=None, retriever=None)
+    #logger.info(MSMarcoEval.results)
+    #logger.info("\nEvaluating Retriever with in-domain data...")
+    #GoldStandardRetrieverEval = IndomainRetrieverEvaluator(encoder=None, retriever=None)
+    #logger.info(GoldStandardRetrieverEval.results)
 
-    logger.info("\nLoading Similarity Evaluation...")
-    SimilarityEval = SimilarityEvaluator(model=None, sample_limit=10)
+    #logger.info("\nLoading Similarity Evaluation...")
+    #SimilarityEval = SimilarityEvaluator(model=None, sample_limit=10)
+    #logger.info("\nEvaluating Similarity Model with NLI Data...")
+    #logger.info(SimilarityEval.results)
+    #print("Evaluating Similarity Model with in-domain data...")
+
+    logger.info("\nLoading Query Expansion Evaluation...")
+    QEEval = QEEvaluator()
     logger.info("\nEvaluating Similarity Model with NLI Data...")
-    logger.info(SimilarityEval.results)
+    logger.info(QEEval.results)
     #print("Evaluating Similarity Model with in-domain data...")

--- a/gamechangerml/scripts/run_evaluation.py
+++ b/gamechangerml/scripts/run_evaluation.py
@@ -1,33 +1,31 @@
-#from gamechangerml.src.model_testing.evaluation import SQuADQAEvaluator, IndomainQAEvaluator, IndomainRetrieverEvaluator, MSMarcoRetrieverEvaluator, SimilarityEvaluator, QEEvaluator
-from gamechangerml.src.model_testing.evaluation import QEEvaluator
+from gamechangerml.src.model_testing.evaluation import SQuADQAEvaluator, IndomainQAEvaluator, IndomainRetrieverEvaluator, MSMarcoRetrieverEvaluator, SimilarityEvaluator, QexpEvaluator
 from gamechangerml.api.utils.logger import logger
 
 if __name__ == '__main__':
 
-    #logger.info("\nStarting QA Evaluation...")
-    #logger.info("\nEvaluating QA with SQuAD Data...")
-    #QAEval = SQuADQAEvaluator(model=None, sample_limit=20)
-    #logger.info(QAEval.results)
-    #logger.info("\nEvaluating QA with in-domain data...")
-    #GCEval = IndomainQAEvaluator(model=None)
-    #logger.info(GCEval.results)
+    logger.info("\nStarting QA Evaluation...")
+    logger.info("\nEvaluating QA with SQuAD Data...")
+    QAEval = SQuADQAEvaluator(model=None, sample_limit=20)
+    logger.info(QAEval.results)
+    logger.info("\nEvaluating QA with in-domain data...")
+    GCEval = IndomainQAEvaluator(model=None)
+    logger.info(GCEval.results)
 
-    #logger.info("\nStarting Retriever Evaluation...")
-    #logger.info("\nEvaluating Retriever with MSMarco Data...")
-    #MSMarcoEval = MSMarcoRetrieverEvaluator(encoder=None, retriever=None)
-    #logger.info(MSMarcoEval.results)
-    #logger.info("\nEvaluating Retriever with in-domain data...")
-    #GoldStandardRetrieverEval = IndomainRetrieverEvaluator(encoder=None, retriever=None)
-    #logger.info(GoldStandardRetrieverEval.results)
+    logger.info("\nStarting Retriever Evaluation...")
+    logger.info("\nEvaluating Retriever with MSMarco Data...")
+    MSMarcoEval = MSMarcoRetrieverEvaluator(encoder=None, retriever=None)
+    logger.info(MSMarcoEval.results)
+    logger.info("\nEvaluating Retriever with in-domain data...")
+    GoldStandardRetrieverEval = IndomainRetrieverEvaluator(encoder=None, retriever=None)
+    logger.info(GoldStandardRetrieverEval.results)
 
-    #logger.info("\nLoading Similarity Evaluation...")
-    #SimilarityEval = SimilarityEvaluator(model=None, sample_limit=10)
-    #logger.info("\nEvaluating Similarity Model with NLI Data...")
-    #logger.info(SimilarityEval.results)
+    logger.info("\nLoading Similarity Evaluation...")
+    SimilarityEval = SimilarityEvaluator(model=None, sample_limit=10)
+    logger.info("\nEvaluating Similarity Model with NLI Data...")
+    logger.info(SimilarityEval.results)
     #print("Evaluating Similarity Model with in-domain data...")
 
     logger.info("\nLoading Query Expansion Evaluation...")
-    QEEval = QEEvaluator()
-    logger.info("\nEvaluating Similarity Model with NLI Data...")
+    QEEval = QexpEvaluator()
+    logger.info("\nEvaluating Query Expansion with GC data...")
     logger.info(QEEval.results)
-    #print("Evaluating Similarity Model with in-domain data...")

--- a/gamechangerml/src/model_testing/evaluation.py
+++ b/gamechangerml/src/model_testing/evaluation.py
@@ -457,7 +457,8 @@ class QEEvaluator():
         else:
             self.QE = QE(**self.config['init'])
 
-        self.data = QEXPDomainData()
+        self.data = QEXPDomainData().data
+        self.results = self.eval()
         
     def predict(self):
 
@@ -467,20 +468,20 @@ class QEEvaluator():
             csvwriter = csv.writer(csvfile)  
             csvwriter.writerow(columns) 
         
-        query_count = 0
-        for query, expected in self.data.items():
-            logger.info(query_count, query)
-            results = self.QE.expand(query, **self.config['expansion'])
-            results = remove_original_kw(results, query)
-            prop_matching = len(set(expected).intersection(results)) / len(results)
-            row = [[
-                    str(query),
-                    str(expected),
-                    str(results),
-                    str(prop_matching)
-                ]]
-            csvwriter.writerows(row)
-            query_count += 1
+            query_count = 0
+            for query, expected in self.data.items():
+                logger.info(query_count, query)
+                results = self.QE.expand(query, **self.config['expansion'])
+                results = remove_original_kw(results, query)
+                prop_matching = len(set(expected).intersection(results)) / len(results)
+                row = [[
+                        str(query),
+                        str(expected),
+                        str(results),
+                        str(prop_matching)
+                    ]]
+                csvwriter.writerows(row)
+                query_count += 1
 
         return pd.read_csv(csv_filename)
 
@@ -490,7 +491,7 @@ class QEEvaluator():
 
         # get overall stats
         proportion_all_match = np.round(df['prop_matching'].value_counts(normalize = True)[1], 2)
-        proportion_any_match = np.round(df['prop_matching'].apply(lambda x: bool(x).value_counts(normalize=True)[True, 2]))
+        proportion_any_match = np.round(df['prop_matching'].apply(lambda x: bool(x)).sum() /  df.shape[0])
         median_match = np.median(df['prop_matching'])
         num_queries = df.shape[0]
 

--- a/gamechangerml/src/model_testing/evaluation.py
+++ b/gamechangerml/src/model_testing/evaluation.py
@@ -6,9 +6,11 @@ import math
 from datetime import datetime
 from gamechangerml.src.search.sent_transformer.model import SentenceEncoder, SentenceSearcher, SimilarityRanker
 from gamechangerml.src.search.QA.QAReader import DocumentReader as QAReader
-from gamechangerml.configs.config import QAConfig, EmbedderConfig, SimilarityConfig, ValidationConfig
+from gamechangerml.src.search.query_expansion.qe import QE
+from gamechangerml.src.search.query_expansion.utils import remove_original_kw
+from gamechangerml.configs.config import QAConfig, EmbedderConfig, SimilarityConfig, QEConfig, ValidationConfig
 from gamechangerml.src.utilities.model_helper import *
-from gamechangerml.src.model_testing.validation_data import SQuADData, NLIData, MSMarcoData, QADomainData, RetrieverGSData
+from gamechangerml.src.model_testing.validation_data import SQuADData, NLIData, MSMarcoData, QADomainData, RetrieverGSData, QEXPDomainData
 from gamechangerml.api.utils.pathselect import get_model_paths
 from gamechangerml.api.utils.logger import logger
 import signal
@@ -435,6 +437,77 @@ class SimilarityEvaluator(TransformerEvaluator):
         }
 
         output_file = timestamp_filename('sim_model_eval', '.json')
+        save_json(output_file, self.model_path, agg_results)
+
+        return agg_results
+
+
+class QEEvaluator():
+
+    def __init__(
+        self, 
+        model=None,
+        config=QEConfig.MODEL_ARGS,
+        ):
+
+        self.config = config
+        self.model_path = self.config['init']['qe_model_dir']
+        if model:
+            self.QE = model
+        else:
+            self.QE = QE(**self.config['init'])
+
+        self.data = QEXPDomainData()
+        
+    def predict(self):
+
+        columns = ['query', 'expected', 'received', 'prop_matching']
+        csv_filename = os.path.join(self.model_path, timestamp_filename('qe_domain', '.csv'))
+        with open(csv_filename, 'w') as csvfile:
+            csvwriter = csv.writer(csvfile)  
+            csvwriter.writerow(columns) 
+        
+        query_count = 0
+        for query, expected in self.data.items():
+            logger.info(query_count, query)
+            results = self.QE.expand(query, **self.config['expansion'])
+            results = remove_original_kw(results, query)
+            prop_matching = len(set(expected).intersection(results)) / len(results)
+            row = [[
+                    str(query),
+                    str(expected),
+                    str(results),
+                    str(prop_matching)
+                ]]
+            csvwriter.writerows(row)
+            query_count += 1
+
+        return pd.read_csv(csv_filename)
+
+    def eval(self):
+
+        df = self.predict()
+
+        # get overall stats
+        proportion_all_match = np.round(df['prop_matching'].value_counts(normalize = True)[1], 2)
+        proportion_any_match = np.round(df['prop_matching'].apply(lambda x: bool(x).value_counts(normalize=True)[True, 2]))
+        median_match = np.median(df['prop_matching'])
+        num_queries = df.shape[0]
+
+        user = get_user(logger)
+
+        agg_results = {
+            "user": user,
+            "date_created": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            "model": self.model_path.split('/')[-1],
+            "validation_data": "QE_domain",
+            "query_count": num_queries,
+            "proportion_all_match": proportion_all_match,
+            "proportion_any_match": proportion_any_match,
+            "median_match": median_match
+        }
+
+        output_file = timestamp_filename('qe_model_eval', '.json')
         save_json(output_file, self.model_path, agg_results)
 
         return agg_results

--- a/gamechangerml/src/model_testing/validation_data.py
+++ b/gamechangerml/src/model_testing/validation_data.py
@@ -189,3 +189,10 @@ class NLIData(ValidationData):
         logger.info(("Created {} sample sentence pairs from {} unique queries:".format(sample.shape[0], sample_limit)))
 
         return sample[['genre', 'gold_label', 'pairID', 'promptID', 'sentence1', 'sentence2', 'expected_rank']]
+
+class QEXPDomainData(ValidationData):
+
+    def __init__(self, validation_config=ValidationConfig.DATA_ARGS):
+
+        super().__init__(validation_config)
+        self.data = open_json(validation_config['qe_gc'], self.validation_dir)['queries']

--- a/gamechangerml/src/search/query_expansion/qe.py
+++ b/gamechangerml/src/search/query_expansion/qe.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 class QE(object):
     __version__ = v.__version__
 
-    def __init__(self, qe_model_dir, method="emb", vocab_file=None):
+    def __init__(self, qe_model_dir, method, vocab_file):
         """
          Query expansion via smoothed inverse frequency weighted word embeddings
          and approximate nearest neighbor search.
@@ -125,7 +125,7 @@ class QE(object):
             logger.exception("{}: {}".format(type(e), str(e)), exc_info=True)
             raise
 
-    def expand(self, query_str, topn=2, threshold=0.2, min_tokens=3):
+    def expand(self, query_str, topn, threshold, min_tokens):
         """
         Expands a query string into the `topn` most similar terms excluding
         the tokens in `query_str`. If a token does not have an embedding,

--- a/gamechangerml/src/search/query_expansion/qe.py
+++ b/gamechangerml/src/search/query_expansion/qe.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 class QE(object):
     __version__ = v.__version__
 
-    def __init__(self, qe_model_dir, method, vocab_file):
+    def __init__(self, qe_model_dir, qe_files_dir, method, vocab_file):
         """
          Query expansion via smoothed inverse frequency weighted word embeddings
          and approximate nearest neighbor search.
@@ -53,6 +53,7 @@ class QE(object):
         self.method = method
         self.empty = np.array([0.0])
         self._alpha = 1e-03
+        self.qe_files_dir = qe_files_dir
         np.set_printoptions(precision=2)
 
         try:
@@ -76,13 +77,14 @@ class QE(object):
 
     def _setup_emb(self, qe_model_dir, vocab_file):
         cfg = QEConfig()
-        here = os.path.dirname(os.path.realpath(__file__))
-        wt_path = os.path.join(here, "aux_data", vocab_file)
+        #here = os.path.dirname(os.path.realpath(__file__))
+        wt_path = os.path.join(self.qe_files_dir, "aux_data", vocab_file)
+        print("wt_path: ", wt_path)
 
         try:
             ann_file, vocab_file = find_ann_indexes(qe_model_dir)
             self._nlp = get_lg_vectors()
-            self.word_wt = get_word_weight(weight_file=wt_path, a=self._alpha)
+            self.word_wt = get_word_weight(weight_file_path=wt_path, a=self._alpha)
 
             logger.info("loading QE indexes")
             vector_dim = spacy_vector_width(self._nlp)

--- a/gamechangerml/src/search/query_expansion/word_wt.py
+++ b/gamechangerml/src/search/query_expansion/word_wt.py
@@ -5,11 +5,11 @@ from gamechangerml.src.search.query_expansion import AUX_DATA_PATH
 logger = logging.getLogger(__name__)
 
 
-def get_word_weight(weight_file="enwiki_vocab_min200.txt", a=1e-3):
+def get_word_weight(weight_file_path, a=1e-3):
     if a <= 0.0:
         a = 1.0
 
-    weight_file_path = os.path.join(AUX_DATA_PATH, weight_file)
+    #weight_file_path = os.path.join(AUX_DATA_PATH, weight_file)
     
     word2weight = dict()
     try:


### PR DESCRIPTION
Made some minor changes to QE:
- pulling changeable args out into config file
- changing the creation of a word_wt path to just accept a filepath from config

In Eval pipeline:
- Added a QEEvaluator class that only works on the QE data from unittests
- Added QE to the run_evaluation.py script

To test QE eval by itself in CLI (from gamechanger-ml):
```python -i
from gamechangerml.src.model_testing.evaluation import QexpEvaluator
QEEval = QexpEvaluator()
print(QEEval.results)
```
