### PR TITLE
[UOT-117114] Updates to text_classification functions to support multi-class classification

### DIFF
--- a/gamechangerml/src/text_classif/bert_classifier.py
+++ b/gamechangerml/src/text_classif/bert_classifier.py
@@ -15,8 +15,9 @@ class BertClassifier(Classifier):
         super(BertClassifier, self).__init__(config_yaml)
 
     def load_model_tokenizer(self):
+        model_name_or_path = self.retrieve_model_name_path()
         self.model = BertForSequenceClassification.from_pretrained(
-            self.cfg.model_name,
+            model_name_or_path,
             num_labels=self.cfg.num_labels,
             output_attentions=False,
             output_hidden_states=False,

--- a/gamechangerml/src/text_classif/classifier.py
+++ b/gamechangerml/src/text_classif/classifier.py
@@ -468,7 +468,12 @@ class Classifier(object):
         if self.cfg.num_labels>2:
             softmax_layer = torch.nn.Softmax(dim=1)
             predicted_probas = softmax_layer(torch.Tensor(np.concatenate(logits_list)))
-            auc_val = clf_metrics.auc_val(self.true_val, predicted_probas, binary_classif=False)
+            try:
+                auc_val = clf_metrics.auc_val(self.true_val, predicted_probas, binary_classif=False)
+            except Exception as e:
+                logger.warning(f"Unable to calcuate AUC for multiclass example, setting AUC to 0, due to following "
+                               f"exception: {e}")
+                auc_val=0.0
         else:
             auc_val = clf_metrics.auc_val(self.true_val, self.predicted_val, binary_classif=True)
 

--- a/gamechangerml/src/text_classif/classifier.py
+++ b/gamechangerml/src/text_classif/classifier.py
@@ -133,6 +133,19 @@ class Classifier(object):
             self.config_yaml,
         )
 
+    def retrieve_model_name_path(self):
+        """
+        This function is used for supplying either the model name, or the saved model directory, when instantiating
+        *ForSequenceClassification() objects. If no load_saved_model_dir is supplied, use the OOTB model from HF, otherwise
+        load in the saved pytorch_model.bin from the load_saved_model_dir specified
+        Returns: (str) model name, or model path, for the HF model
+        """
+        if self.cfg.load_saved_model_dir:
+            model_name_or_path = self.cfg.load_saved_model_dir
+        else:
+            model_name_or_path = self.cfg.model_name
+        return model_name_or_path
+
     def train_test_ds(self, texts, labels):
         """
         Split into training and validation subsets; create `TensorDataset`s

--- a/gamechangerml/src/text_classif/classifier.py
+++ b/gamechangerml/src/text_classif/classifier.py
@@ -498,8 +498,7 @@ class Classifier(object):
         logger.info("confusion matrix\n\n\t{}\n".format(cm_matrix))
         logger.info("\tvalidation loss : {:>0.3f}".format(avg_val_loss))
         logger.info("\t            MCC : {:>0.3f}".format(mcc))
-        if self.cfg.num_labels <= 2:
-            logger.info("\t            AUC : {:>0.3f}".format(auc_val))
+        logger.info("\t            AUC : {:>0.3f}".format(auc_val))
         logger.info("\t accuracy score : {:>0.3f}".format(acc_score))
         logger.info("\tvalidation time : {:}".format(validation_time))
 

--- a/gamechangerml/src/text_classif/distilbert_classifier.py
+++ b/gamechangerml/src/text_classif/distilbert_classifier.py
@@ -22,12 +22,13 @@ class DistilBertClassifier(Classifier):
             None
 
         """
+        model_name_or_path = self.retrieve_model_name_path()
         self.model = DistilBertForSequenceClassification.from_pretrained(
-            self.cfg.model_name,
+            model_name_or_path,
             num_labels=self.cfg.num_labels,
             output_attentions=False,
             output_hidden_states=False,
-            return_dict=True,
+            return_dict=True
         )
         self.tokenizer = DistilBertTokenizer.from_pretrained(
             self.cfg.model_name, do_lower_case=True

--- a/gamechangerml/src/text_classif/roberta_classifier.py
+++ b/gamechangerml/src/text_classif/roberta_classifier.py
@@ -23,8 +23,9 @@ class RobertaClassifier(Classifier):
 
         """
         logger.info("loading model tokenizer")
+        model_name_or_path = self.retrieve_model_name_path()
         self.model = RobertaForSequenceClassification.from_pretrained(
-            self.cfg.model_name,
+            model_name_or_path,
             num_labels=self.cfg.num_labels,
             output_attentions=False,
             output_hidden_states=False,

--- a/gamechangerml/src/text_classif/utils/config.py
+++ b/gamechangerml/src/text_classif/utils/config.py
@@ -16,6 +16,7 @@ cfg_schema = {
     "epochs": int,
     "batch_size": int,
     "random_state": int,
+    "load_saved_model_dir": (str, type_none),
     "checkpoint_path": (str, type_none),
     "tensorboard_path": (str, type_none),
     "num_labels": int,

--- a/gamechangerml/src/text_classif/utils/metrics.py
+++ b/gamechangerml/src/text_classif/utils/metrics.py
@@ -14,8 +14,8 @@ def logit_score(logits):
     return score.tolist()
 
 
-def auc_val(y_true, y_logits):
-    auc = metrics.roc_auc_score(y_true, y_logits)
+def auc_val(y_true, y_logits, binary_classif=True):
+    auc = metrics.roc_auc_score(y_true, y_logits, multi_class="raise" if binary_classif else "ovr")
     return auc
 
 


### PR DESCRIPTION
`JIRA Ticket`: https://jira.di2e.net/browse/UOT-117114
`Description`: When building out classifier models (4 labels) for JBOOK utilizing the `text_classif` modules/utilities, some updates were required in order to leverage the modules for multi-class classification.

`Updates include`:
* Addition of `__init__.py` within `text_classif` so that the classes/modules are importable.
* Updating AUC calculation to support multi-class (if multiclass classif, use `one-vs-rest` AUC calculation
* Add in support for `load_saved_model_dir`, which allows the classification models (bert/distilbert/roberta) to be warmstarted from a folder containing a trained model on disk, rather than only supporting the HF OOTB models
    * This also included small updates to each of the `*_classifier.py` classes when loading in `from_pretrained`
    * Addition of `retrieve_model_name_path` to classifier.py

`Changes Requested` ⚒️ 
* .