### PR TITLE
Add topic option in api call

### DIFF
--- a/gamechangerml/api/fastapi/model_loader.py
+++ b/gamechangerml/api/fastapi/model_loader.py
@@ -96,7 +96,7 @@ class ModelLoader:
             logger.warning(
                 "topic_model was not set and was attempted to be used. Running init"
             )
-            ModelLoader.initSentenceEncoder()
+            ModelLoader.initTopics()
         return ModelLoader.__topic_model
 
     def set_error(self):

--- a/gamechangerml/api/fastapi/model_loader.py
+++ b/gamechangerml/api/fastapi/model_loader.py
@@ -5,19 +5,25 @@ from gamechangerml.configs.config import (
     EmbedderConfig,
     SimilarityConfig,
     QexpConfig,
+    TopicsConfig,
 )
 from gamechangerml.src.search.query_expansion import qe
-from gamechangerml.src.search.sent_transformer.model import SentenceSearcher, SentenceEncoder
+from gamechangerml.src.search.sent_transformer.model import (
+    SentenceSearcher,
+    SentenceEncoder,
+)
 from gamechangerml.src.search.embed_reader import sparse
 from gamechangerml.src.search.ranking import ltr
 from gamechangerml.api.fastapi.settings import *
 from gamechangerml.src.featurization.word_sim import WordSim
+from gamechangerml.src.featurization.topic_modeling import Topics
 
 # A singleton class that loads all of the models.
 # All variables and methods are static so you
 # reference them by ModelLoader().example_method()
 
-#SENT_INDEX_PATH.value = 'gamechangerml/models/sent_index_TEST'
+# SENT_INDEX_PATH.value = 'gamechangerml/models/sent_index_TEST'
+
 
 class ModelLoader:
     # private model variables
@@ -31,6 +37,7 @@ class ModelLoader:
     __query_expander_jbook = None
     __word_sim = None
     __sparse_reader = None
+    __topic_model = None
 
     # Get methods for the models. If they don't exist try initializing them.
     def getQA(self):
@@ -84,6 +91,14 @@ class ModelLoader:
     def getSparse(self):
         return ModelLoader.__sparse_reader
 
+    def getTopicModel(self):
+        if ModelLoader.__topic_model is None:
+            logger.warning(
+                "topic_model was not set and was attempted to be used. Running init"
+            )
+            ModelLoader.initSentenceEncoder()
+        return ModelLoader.__topic_model
+
     def set_error(self):
         logger.error("Models cannot be directly set. Must use init methods.")
 
@@ -96,6 +111,7 @@ class ModelLoader:
     sentence_searcher = property(getSentence_searcher, set_error)
     sentence_encoder = property(getSentence_encoder, set_error)
     word_sim = property(getWordSim, set_error)
+    topic_model = property(getTopicModel, set_error)
 
     @staticmethod
     def initQA():
@@ -183,7 +199,9 @@ class ModelLoader:
             sim_model = ModelLoader.__sentence_searcher.similarity
             # set cache variable defined in settings.py
             latest_intel_model_sim.value = sim_model.sim_model
-            logger.info(f"** Loaded Similarity Model from {sim_model.sim_model} and sent index from {index_path}")
+            logger.info(
+                f"** Loaded Similarity Model from {sim_model.sim_model} and sent index from {index_path}"
+            )
 
         except Exception as e:
             logger.warning("** Could not load Similarity model")
@@ -201,7 +219,7 @@ class ModelLoader:
             ModelLoader.__sentence_encoder = SentenceEncoder(
                 encoder_model_name=EmbedderConfig.BASE_MODEL,
                 transformer_path=transformer_path,
-                **EmbedderConfig.MODEL_ARGS
+                **EmbedderConfig.MODEL_ARGS,
             )
             encoder_model = ModelLoader.__sentence_encoder.encoder_model
             # set cache variable defined in settings.py
@@ -215,9 +233,26 @@ class ModelLoader:
     @staticmethod
     def initSparse(model_name=latest_intel_model_trans.value):
         try:
-            ModelLoader.__sparse_reader = sparse.SparseReader(
-                model_name=model_name)
+            ModelLoader.__sparse_reader = sparse.SparseReader(model_name=model_name)
             logger.info(f"Sparse Reader: {model_name} loaded")
         except Exception as e:
             logger.warning("** Could not load Sparse Reader")
             logger.warning(e)
+
+    @staticmethod
+    def initTopics() -> None:
+        """initTopics - load topics model on start
+        Args:
+        Returns:
+        """
+        try:
+            logger.info("Starting Topic pipeline")
+            logger.info(TopicsConfig.DATA_ARGS)
+            ModelLoader.__topic_model = Topics(
+                TopicsConfig.DATA_ARGS["LOCAL_MODEL_DIR"]
+            )
+            logger.info("Finished loading Topic Model")
+        except Exception as e:
+            logger.warning("** Could not load Topic model")
+            logger.warning(e)
+

--- a/gamechangerml/api/fastapi/routers/startup.py
+++ b/gamechangerml/api/fastapi/routers/startup.py
@@ -16,6 +16,7 @@ async def load_models():
     MODELS.initSentenceEncoder()
     MODELS.initSentenceSearcher()
     MODELS.initWordSim()
+    MODELS.initTopics()
 
 
 @router.on_event("startup")

--- a/gamechangerml/configs/config.py
+++ b/gamechangerml/configs/config.py
@@ -76,14 +76,13 @@ class EmbedderConfig:
     MODEL_ARGS = {
         "min_token_len": 10,
         "verbose": True,  # for creating LocalCorpus
-        "return_id": True  # for creating LocalCorpus
+        "return_id": True,  # for creating LocalCorpus
     }
-    FINETUNE = {"shuffle": True, "batch_size": 32,
-                "epochs": 3, "warmup_steps": 100}
+    FINETUNE = {"shuffle": True, "batch_size": 32, "epochs": 3, "warmup_steps": 100}
 
 
 class SimilarityConfig:
-    BASE_MODEL = "distilbart-mnli-12-3" 
+    BASE_MODEL = "distilbart-mnli-12-3"
 
 
 class QexpConfig:
@@ -129,17 +128,11 @@ class ValidationConfig:
         "matamo_dir": "gamechangerml/data/validation/matamo",
         "search_hist_dir": "gamechangerml/data/validation/search_history",
         "qe_gc": "QE_domain.json",
-        "start_date": "2020-12-01", # earliest date to include search hist/feedback data from
-        "end_date": "2025-12-01", # last date to include search hist/feedback data from
+        "start_date": "2020-12-01",  # earliest date to include search hist/feedback data from
+        "end_date": "2025-12-01",  # last date to include search hist/feedback data from
         "exclude_searches": ["pizza", "shark"],
-        "gold_level": {
-            "min_correct_matches": 3,
-            "max_results": 7
-        },
-        "silver_level": {
-            "min_correct_matches": 2,
-            "max_results": 10
-        }
+        "gold_level": {"min_correct_matches": 3, "max_results": 7},
+        "silver_level": {"min_correct_matches": 2, "max_results": 10},
     }
 
 
@@ -148,3 +141,7 @@ class TrainingConfig:
         "training_data_dir": "gamechangerml/data/training",
         "train_test_split_ratio": 0.8,
     }
+
+
+class TopicsConfig:
+    DATA_ARGS = {"LOCAL_MODEL_DIR": os.path.join(REPO_PATH, "gamechangerml/models")}

--- a/gamechangerml/scripts/download_dependencies.sh
+++ b/gamechangerml/scripts/download_dependencies.sh
@@ -1,31 +1,35 @@
 #!/bin/bash
 echo "Be sure to set up environment variables for s3 by sourcing setup_env.sh if running this manually"
+
+MODELS_DEST=$PWD/gamechangerml/models/.
+DATA_DEST=$PWD/gamechangerml/data/.
+
 echo "Downloading Transformers Folder"
 echo "S3 MODEL PATH TRANSFORMERS: $S3_TRANS_MODEL_PATH"
 #python -c "from gamechangerml.src.utilities.utils import get_transformer_cache; get_transformer_cache(model_path='$S3_TRANS_MODEL_PATH', overwrite=False)"
-aws s3 cp "$S3_TRANS_MODEL_PATH" $PWD/gamechangerml/models/.
-
-echo "Downloading Data Folder"
-echo "DATA DIRECTORY: $S3_ML_DATA_PATH"
-#python -c "from gamechangerml.src.utilities.utils import get_transformer_cache; get_transformer_cache(model_path='$S3_TRANS_MODEL_PATH', overwrite=False)"
-aws s3 cp "$S3_ML_DATA_PATH" $PWD/gamechangerml/data/.
+aws s3 cp "$S3_TRANS_MODEL_PATH" $MODELS_DEST
 
 echo "Downloading Sentence Index"
 echo "S3 MODEL PATH SENTENCE INDEX: $S3_SENT_INDEX_PATH"
-aws s3 cp "$S3_SENT_INDEX_PATH" $PWD/gamechangerml/models/.
+aws s3 cp "$S3_SENT_INDEX_PATH" $MODELS_DEST
 #python -c "from gamechangerml.src.utilities.utils import get_sentence_index; get_sentence_index(model_path='$S3_SENT_INDEX_PATH',overwrite=False)"
 
 echo "Downloading QE Model"
 echo "S3 QE MODEL: $S3_QEXP_PATH"
-aws s3 cp "$S3_QEXP_PATH" $PWD/gamechangerml/models/.
+aws s3 cp "$S3_QEXP_PATH" $MODELS_DEST
 
 echo "Downloading JBOOK QE Model"
 echo "S3 JBOOK QE MODEL: $S3_QEXP_JBOOK_PATH"
-aws s3 cp "$S3_QEXP_JBOOK_PATH" $PWD/gamechangerml/models/.
+aws s3 cp "$S3_QEXP_JBOOK_PATH" $MODELS_DEST
 
 echo "Downloading Topic Model"
 echo "S3 TOPIC MODEL: $S3_TOPICS_PATH"
-aws s3 cp "$S3_TOPICS_PATH" $PWD/gamechangerml/models/topic_models/
+aws s3 cp "$S3_TOPICS_PATH" $MODELS_DEST
+
+echo "Downloading Data Folder"
+echo "DATA DIRECTORY: $S3_ML_DATA_PATH"
+#python -c "from gamechangerml.src.utilities.utils import get_transformer_cache; get_transformer_cache(model_path='$S3_TRANS_MODEL_PATH', overwrite=False)"
+aws s3 cp "$S3_ML_DATA_PATH" $DATA_DEST
 
 echo "Uncompressing all tar files in models"
 for f in ./gamechangerml/models/*.tar.gz; do

--- a/gamechangerml/src/featurization/topic_modeling.py
+++ b/gamechangerml/src/featurization/topic_modeling.py
@@ -1,6 +1,8 @@
 from gamechangerml.src.text_handling.custom_stopwords import custom_stopwords
+from gamechangerml.src.text_handling.process import topic_processing
 from gensim.models.tfidfmodel import TfidfModel
 from gensim import corpora
+from gensim.models.phrases import Phraser
 import os
 import logging
 
@@ -11,7 +13,7 @@ class Topics(object):
     """
     TF-iDF topic model wrapper class.
 
-    This class is written to be processing pipeline egnostic, but
+    This class is written to be processing pipeline agnostic, but
     because of that be sure that you track your own pipeline for
     training and inference otherwise results may vary.
 
@@ -68,8 +70,10 @@ class Topics(object):
         """
         dictionary_path = os.path.join(directory, "tfidf_dictionary.dic")
         tfidf_path = os.path.join(directory, "tfidf.model")
+        bigrams_path = os.path.join(directory, "bigrams.phr")
         self.dictionary = corpora.Dictionary.load(dictionary_path)
         self.tfidf = TfidfModel.load(tfidf_path)
+        self.bigrams = Phraser.load(bigrams_path)
 
     def save(self, directory):
         """
@@ -101,6 +105,10 @@ class Topics(object):
         self.dictionary = corpora.Dictionary(corpus)
         doc_term_matrix = [self.dictionary.doc2bow(doc) for doc in corpus]
         self.tfidf = TfidfModel(doc_term_matrix)
+
+    def get_topics_from_text(self, text, topn=5):
+        tokens = topic_processing(text, self.bigrams)
+        return self.get_topics(tokens, topn=topn)
 
     def get_topics(self, tokens, topn=5):
         """


### PR DESCRIPTION
Adds topic model initialization when router starts
Adds matching methods and Config for init/get in ModelLoader

download_dependencies.sh - put model and data paths into a variable (the topics path was wrong and it wasnt being unzipped with the other models)

search.py - changed the first arg in each route to be "body" for clarity
