### PR TITLE
bugfix - recommender tests

### DIFF
--- a/gamechangerml/api/tests/api_tests.py
+++ b/gamechangerml/api/tests/api_tests.py
@@ -115,7 +115,7 @@ def test_postSentSearch():
     #     assert abs(resp.json()[i]['score'] - verified[i]['score']) < .01
     assert len(resp.json()) > 5
 
-def test_recommender_results():
+def test_recommender():
     test_data = TestSet.recommender_data
     expected = TestSet.recommender_results
 

--- a/gamechangerml/api/tests/api_tests.py
+++ b/gamechangerml/api/tests/api_tests.py
@@ -115,12 +115,14 @@ def test_postSentSearch():
     #     assert abs(resp.json()[i]['score'] - verified[i]['score']) < .01
     assert len(resp.json()) > 5
 
-def test_recommender():
+def test_recommender_results():
     test_data = TestSet.recommender_data
     expected = TestSet.recommender_results
 
     resp = http.post(API_URL + "/recommender", json=test_data)
-    assert resp.json() == expected
+    data =  resp.json() 
+    assert len(data['results']) == 5
+    assert len(set(expected['results']).intersection(data['results'])) > 0
 
 ## QA Tests
 

--- a/gamechangerml/api/tests/test_examples.py
+++ b/gamechangerml/api/tests/test_examples.py
@@ -83,7 +83,7 @@ class TestSet:
     }
 
     recommender_data = {"filename": "Title 10"}
-    recommender_results = {'filename': 'Title 10', 'results': ['AACP 02.1', 'Title 50', 'AFH 10-644', 'AFI 36-2710', 'AFMAN 11-2HH-60V3CL-1', 'ARMY DIR 2017-32']}
+    recommender_results = {'filename': 'Title 10', 'results':  ['Title 50', 'AACP 02.1', 'DoDD 5143.01 CH 2', 'DoDD S-5230.28', 'DoDI 5000.89']}
 
     # extraction_data = {"text": "Carbon emissions trading is poised to go global, and billions of dollars — maybe even trillions — could be at stake. That's thanks to last month's U.N. climate summit in Glasgow Scotland, which approved a new international trading system where companies pay for cuts in greenhouse gas emissions somewhere else, rather than doing it themselves."}
     # extraction_keywords_expect = {

--- a/gamechangerml/src/recommender/recommend.py
+++ b/gamechangerml/src/recommender/recommend.py
@@ -82,7 +82,7 @@ class Recommender:
             g_results = self._lookup_history(filename)
             if len(g_results) > 0:
                 for x in g_results:
-                    if len(results) <= limit:
+                    if len(results) < limit:
                         if in_corpus(x, corpus_list):
                             results.append(x)
                     else:


### PR DESCRIPTION
### Description:
- Updated recommender test examples based on newest SearchPDFMapping results
- Updated recommender test to be less strict (expect 5 results for searching Title 10, expect some overlap between expected and actual results)
- Fixed recommender code to return 5 not 6 results

### Manual Testing:
- From backend, hit mlapi `/recommender` with filename: `{"filename":"Title 10"}`

### Unittests:
```gamechangerml/api/tests/api_tests.py::test_recommender_results PASSED```
