### PR TITLE
Patch requirements. Add huggingface-hub to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ fuzzywuzzy~=0.18.0
 gensim==4.1.2
 gunicorn~=20.1.0
 httptools~=0.1.2
+huggingface-hub==0.1.2
 matplotlib~=3.4.3
 networkx~=2.6.3
 nltk~=3.6.5
@@ -41,5 +42,5 @@ uvloop~=0.14.0
 wikipedia~=1.4.0
 xgboost==1.1.0
 debugpy~=1.6.2
-mlflow~=1.27.0
+mlflow
 psutil~=5.9.1


### PR DESCRIPTION
# Description

Issues addressed:

1. mlflow~=1.27.0 causes `ERROR: No matching distribution found for mlflow~=1.27.0`. Changing to to not having a version fixed it.
2. huggingface-hub needed added to requirements.txt otherwise when the ml-api container would try to run it would fail. The error would say something to the effect of `No module named 'huggingface_hub.snapshot_download'`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Local

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have used an autoformatter like lint or blackc

- [ ] This requires a code review
